### PR TITLE
chore(subgraph): Add Github issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug.yml
@@ -1,0 +1,53 @@
+name: 🐛 Bug Report
+description: This form is to report a bug
+title: "[Bug]: "
+labels: ["type:bug", ":new: needs-triage"]
+body:
+    - type: markdown
+      attributes:
+          value: |
+              Thank you for taking your precious time to file an issue!
+
+              We know that your time is precious, but the first step in fixing this issue is to understand the issue. Taking some extra time to ensure that we are able to reproduce the issue will help us significantly in resolving the issue.
+    - type: dropdown
+      id: package
+      attributes:
+          label: Which package is that happening?
+          description: Select the appropriate package(s).
+          multiple: true
+          options:
+              - block-subgraph
+              - eligibility
+              - pos-subgraph
+              - rollups-subgraph
+              - toolbox
+      validations:
+          required: true
+    - type: textarea
+      id: expected-behaviour
+      attributes:
+          label: 🙂 Expected behavior
+          description: What is expected to happen?
+      validations:
+          required: true
+    - type: textarea
+      id: actual-behaviour
+      attributes:
+          label: 🫠 Actual behavior
+          description: What is happening instead?
+      validations:
+          required: true
+    - type: textarea
+      id: minimal-test-case
+      attributes:
+          label: 🧪 Minimal test case
+          description: |
+              Please describe a minimal test case that demonstrates the bug. 
+              If possible, this should be an automated test.
+      validations:
+          required: true
+    - type: textarea
+      id: extra-information
+      attributes:
+          label: 📄 Extra information
+          description: Anything else that might be relevant?

--- a/.github/ISSUE_TEMPLATE/2-feature.md
+++ b/.github/ISSUE_TEMPLATE/2-feature.md
@@ -1,0 +1,26 @@
+---
+name: ✨ Feature request
+about: Template for requesting new features
+title: ''
+labels: 'type:feature'
+assignees: ''
+---
+
+## 📄 Context
+
+What is the problem that you are trying to solve?
+Why is this problem relevant?
+
+## ✔️ Solution
+
+(This section and the ones below are optional.)
+What are the possible solutions?
+If there are multiple, what are the benefits and drawbacks of each one?
+
+## 📈 Subtasks
+
+-   [ ] If there is a solution, what are the subtasks for completing this issue?
+
+## 🎯 Definition of Done
+
+-   [ ] If there is a solution, what are the final deliverables?

--- a/.github/ISSUE_TEMPLATE/3-technical-debt.md
+++ b/.github/ISSUE_TEMPLATE/3-technical-debt.md
@@ -1,0 +1,28 @@
+---
+name: 🏗️ Technical Debt
+about: Template for proposing solutions to technical debts
+title: ''
+labels: type:refactor
+assignees: ''
+---
+
+## 📄 Context
+
+What is the problem that you are trying to solve?
+Why is this problem relevant?
+How this problem afects the feature roadmap?
+Is it a blocker to implement a new feature?
+What parts of the architecture and/or code are affected?
+
+## ✔️ Solution
+
+What are the possible solutions?
+If there are multiple, what are the benefits and drawbacks of each one?
+
+## 📈 Subtasks
+
+-   [ ] What are the subtasks for completing this issue?
+
+## 🎯 Definition of Done
+
+-   [ ] What are the final deliverables?

--- a/.github/ISSUE_TEMPLATE/4-update-dependencies.md
+++ b/.github/ISSUE_TEMPLATE/4-update-dependencies.md
@@ -1,0 +1,21 @@
+---
+name: ⬆️ Update Dependencies
+about: Template for updating dependencies
+title: ''
+labels: type:chore
+assignees: ''
+---
+
+## 📄 Context
+
+Please provide a clean and concise description of what dependency/dependencies will be updated and the expected impacts.
+What are the dependency or dependencies to be updated?
+What are the parts of the code that will be affected by this action?
+Why is that update relevant?
+
+## 📈 Subtasks
+
+-   [ ] Update the package.json to the new fixed version ( i.e. no ^ or ~ )
+-   [ ] If an update requires major work, create the corresponding issue.
+-   [ ] Make sure dependencies are updated in the lock file (yarn.lock).
+-   [ ] Verify whether everything is working as expected.

--- a/.github/ISSUE_TEMPLATE/5-documentation.md
+++ b/.github/ISSUE_TEMPLATE/5-documentation.md
@@ -1,0 +1,27 @@
+---
+name: "📖 Documentation issue"
+about: Help improve our docs.
+labels: "type:docs"
+---
+
+## 📄 Context
+
+<!-- (Update "[ ]" to "[x]" to check a box) -->
+
+-   [ ] Reporting a typo
+-   [ ] Reporting a documentation bug
+-   [ ] Documentation improvement
+-   [ ] Documentation feedback
+
+<!--
+  If your issue is not regarding the documentation, please choose an issue type:
+  https://github.com/cartesi/subgraph/issues/new/choose
+-->
+
+### Is there a specific documentation page you are reporting?
+
+Enter the URL or documentation section here.
+
+### Additional context or description
+
+Provide any additional details here as needed.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+    - name: 🤔 Questions and Help
+      url: https://discord.gg/cartesi
+      about: This issue tracker is not for support questions. Please refer to the discord Cartesi Development Community server for help and discussion.


### PR DESCRIPTION
Add form for bug reports and issue templates for feature requests, tech debt, documentation and update dependency. Also include config with contact information pointing to the Cartesi discord server.