### PR TITLE
chore: Upgrade rollups library

### DIFF
--- a/packages/rollups-subgraph/package.json
+++ b/packages/rollups-subgraph/package.json
@@ -2,8 +2,6 @@
     "name": "@cartesi/subgraph-rollups",
     "version": "0.1.0",
     "description": "Cartesi Rollups Subgraph",
-    "main": "index.js",
-    "author": "Danilo Tuler <danilo.tuler@cartesi.io>",
     "license": "Apache-2.0",
     "scripts": {
         "codegen": "graph codegen",

--- a/packages/rollups-subgraph/package.json
+++ b/packages/rollups-subgraph/package.json
@@ -27,7 +27,7 @@
         "test": "graph test"
     },
     "dependencies": {
-        "@cartesi/rollups": "^0.9.0",
+        "@cartesi/rollups": "^0.9.1",
         "@graphprotocol/graph-cli": "^0.34.0",
         "@graphprotocol/graph-ts": "^0.28.0"
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -55,10 +55,10 @@
   optionalDependencies:
     fsevents "^2.3.2"
 
-"@cartesi/rollups@^0.9.0":
-  version "0.9.0"
-  resolved "https://registry.yarnpkg.com/@cartesi/rollups/-/rollups-0.9.0.tgz#a0344a5d8a75b8c6f7f398739b6072e9395b8f18"
-  integrity sha512-ilmyHTJFyiIHopzJbmaTGRW+oPkbUnxkCZyAsxIAnUOjPzvlXRmukXubfL92lB/JvCqaSkCz8Gm/GXy1kw7AVQ==
+"@cartesi/rollups@^0.9.1":
+  version "0.9.1"
+  resolved "https://registry.yarnpkg.com/@cartesi/rollups/-/rollups-0.9.1.tgz#f6cd6294553b799016b721463160c65dadc6ff44"
+  integrity sha512-KTkvmRvWGKfecv2Vlnr6PmyNrVAtQBwzoAoqATWnZafOO06Pl/jSqVjyewLHsz+44tEst6lRsV8WDos4FeGlUA==
   dependencies:
     "@cartesi/util" "^5.0.2"
     "@openzeppelin/contracts" "4.8.0"


### PR DESCRIPTION
### Summary
Upgrade cartesi/rollups library to its latest version. Also, update some properties on rollups-subgraph package.json.

