### PR TITLE
chore: Update matchstick-as version.

### DIFF
--- a/packages/pos-subgraph/package.json
+++ b/packages/pos-subgraph/package.json
@@ -39,7 +39,7 @@
         "hardhat": "^2.12.2",
         "hardhat-deploy": "^0.11.20",
         "js-yaml": "^4.1.0",
-        "matchstick-as": "0.5.0",
+        "matchstick-as": "0.5.2",
         "rimraf": "^3.0.2",
         "ts-node": "^10.3.1",
         "typescript": "^4.9.3"

--- a/packages/rollups-subgraph/package.json
+++ b/packages/rollups-subgraph/package.json
@@ -36,7 +36,7 @@
         "ethers": "^5.7.1",
         "hardhat": "^2.12.2",
         "hardhat-deploy": "^0.11.20",
-        "matchstick-as": "^0.5.0",
+        "matchstick-as": "0.5.2",
         "ts-node": "^10.9.1",
         "typescript": "^4.8.3"
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -742,7 +742,7 @@
     which "2.0.2"
     yaml "1.9.2"
 
-"@graphprotocol/graph-ts@0.27.0", "@graphprotocol/graph-ts@^0.27.0":
+"@graphprotocol/graph-ts@0.27.0":
   version "0.27.0"
   resolved "https://registry.yarnpkg.com/@graphprotocol/graph-ts/-/graph-ts-0.27.0.tgz#948fe1716f6082964a01a63a19bcbf9ac44e06ff"
   integrity sha512-r1SPDIZVQiGMxcY8rhFSM0y7d/xAbQf5vHMWUf59js1KgoyWpM6P3tczZqmQd7JTmeyNsDGIPzd9FeaxllsU4w==
@@ -7735,13 +7735,11 @@ match-all@^1.2.6:
   resolved "https://registry.yarnpkg.com/match-all/-/match-all-1.2.6.tgz#66d276ad6b49655551e63d3a6ee53e8be0566f8d"
   integrity sha512-0EESkXiTkWzrQQntBu2uzKvLu6vVkUGz40nGPbSZuegcfE5UuSzNjLaIu76zJWuaT/2I3Z/8M06OlUOZLGwLlQ==
 
-matchstick-as@0.5.0, matchstick-as@^0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/matchstick-as/-/matchstick-as-0.5.0.tgz#cdafc1ef49d670b9cbe98e933bc2a5cb7c450aeb"
-  integrity sha512-4K619YDH+so129qt4RB4JCNxaFwJJYLXPc7drpG+/mIj86Cfzg6FKs/bA91cnajmS1CLHdhHl9vt6Kd6Oqvfkg==
+matchstick-as@0.5.2:
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/matchstick-as/-/matchstick-as-0.5.2.tgz#6a6dde02d1d939c32458bd67bac688891a07a34c"
+  integrity sha512-fb1OVphDKEvJY06Ue02Eh1CNncuW95vp6b8tNAP7UIqplICSLoU/zgN6U7ge7R0upsoO78C7CRi4EyK/7Jxz7g==
   dependencies:
-    "@graphprotocol/graph-ts" "^0.27.0"
-    assemblyscript "^0.19.20"
     wabt "1.0.24"
 
 matchstick-as@^0.2.3:


### PR DESCRIPTION
### Summary
Upgrade the matchstick-as to its latest version, nothing major like v0.5.0; all tests are compiling and running as expected. There is a [v0.6.0](https://github.com/LimeChain/matchstick/releases) of the library in the works, but it is still in Beta; so I am not moving to this version. 