### PR TITLE
chore: Subgraph monitoring action

### DIFF
--- a/.github/workflows/called-subgraph-build.yml
+++ b/.github/workflows/called-subgraph-build.yml
@@ -24,7 +24,7 @@ jobs:
             - name: Setup Node.js environment
               uses: actions/setup-node@v3
               with:
-                  node-version: "18"
+                  node-version: "22"
                   cache: "yarn"
             - run: yarn install --frozen-lockfile
             - name: Code format check

--- a/.github/workflows/monitoring.yml
+++ b/.github/workflows/monitoring.yml
@@ -1,5 +1,8 @@
 name: Subgraph Monitoring
-on: [push, workflow_dispatch]
+on:
+  schedule:
+    - cron: "0 */3 * * *"
+  workflow_dispatch:
 jobs:
   monitor:
     runs-on: ubuntu-latest
@@ -38,6 +41,6 @@ jobs:
           private-key: ${{ secrets.PRIVATE_KEY }}
       - name: Create Issue and mention team
         run: |
-          gh issue create --title "[testing] Subgraph Indexing unbalanced" --body "${{ vars.TEAM_NAME }}: **Workflow failure** [View workflow run for details](https://github.com/${{ github.repository}}/actions/runs/${{ github.run_id}})"
+          gh issue create --title "Subgraph Indexing unbalanced" --body "${{ vars.TEAM_NAME }}: **Workflow failure** [View workflow run for details](https://github.com/${{ github.repository}}/actions/runs/${{ github.run_id}})"
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/monitoring.yml
+++ b/.github/workflows/monitoring.yml
@@ -1,7 +1,5 @@
 name: Subgraph Monitoring
-on:
-  workflow_dispatch:
-
+on: [push, workflow_dispatch]
 jobs:
   monitor:
     runs-on: ubuntu-latest
@@ -33,13 +31,14 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
-      - uses: actions/create-github-app-token@v2
-        id: app-token
-        with:
-          app-id: ${{ vars.APP_ID }}
-          private-key: ${{ secrets.PRIVATE_KEY }}
+      # - uses: actions/create-github-app-token@v2
+      #   id: app-token
+      #   with:
+      #     app-id: ${{ vars.APP_ID }}
+      #     private-key: ${{ secrets.PRIVATE_KEY }}
       - name: Create Issue and mention team
         run: |
-          gh issue create --title "Subgraph Indexing unbalanced" --body "${{ vars.TEAM_NAME }}: **Workflow failure** [View workflow run for details](https://github.com/${{ github.repository}}/actions/runs/${{ github.run_id}})"
+          gh issue create --title "[testing] Subgraph Indexing unbalanced" --body "${{ vars.TEAM_NAME }}: **Workflow failure** [View workflow run for details](https://github.com/${{ github.repository}}/actions/runs/${{ github.run_id}})"
         env:
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          # GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/monitoring.yml
+++ b/.github/workflows/monitoring.yml
@@ -31,14 +31,13 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
-      # - uses: actions/create-github-app-token@v2
-      #   id: app-token
-      #   with:
-      #     app-id: ${{ vars.APP_ID }}
-      #     private-key: ${{ secrets.PRIVATE_KEY }}
+      - uses: actions/create-github-app-token@v2
+        id: app-token
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.PRIVATE_KEY }}
       - name: Create Issue and mention team
         run: |
           gh issue create --title "[testing] Subgraph Indexing unbalanced" --body "${{ vars.TEAM_NAME }}: **Workflow failure** [View workflow run for details](https://github.com/${{ github.repository}}/actions/runs/${{ github.run_id}})"
         env:
-          # GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/monitoring.yml
+++ b/.github/workflows/monitoring.yml
@@ -1,0 +1,45 @@
+name: Subgraph Monitoring
+on:
+  workflow_dispatch:
+
+jobs:
+  monitor:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v3
+        with:
+          node-version: "22"
+          cache: "yarn"
+
+      - run: yarn install --frozen-lockfile
+
+      - name: Run Monitoring
+        env:
+          MONITOR_ALERT_THRESHOLD: ${{vars.MONITOR_ALERT_THRESHOLD}}
+          RPC_URL_11155111: ${{ secrets.RPC_URL_11155111 }}
+          RPC_URL_1: ${{ secrets.RPC_URL_1 }}
+          ALCHEMY_MAINNET_URL: ${{ secrets.ALCHEMY_MAINNET_URL }}
+          CHAINSTACK_MAINNET_URL: ${{ secrets.CHAINSTACK_MAINNET_URL }}
+          CHAINSTACK_SEPOLIA_URL: ${{ secrets.CHAINSTACK_SEPOLIA_URL }}
+        run: yarn run:monitoring
+  alert-on-failure:
+    needs: [monitor]
+    if: ${{ failure() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+      - uses: actions/create-github-app-token@v2
+        id: app-token
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.PRIVATE_KEY }}
+      - name: Create Issue and mention team
+        run: |
+          gh issue create --title "Subgraph Indexing unbalanced" --body "${{ vars.TEAM_NAME }}: **Workflow failure** [View workflow run for details](https://github.com/${{ github.repository}}/actions/runs/${{ github.run_id}})"
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/additional.d.ts
+++ b/additional.d.ts
@@ -1,0 +1,28 @@
+declare namespace NodeJS {
+    export interface ProcessEnv {
+        /**
+         * Limit for acceptable block number distance.
+         */
+        MONITOR_ALERT_THRESHOLD: string
+        /**
+         * Ethereum sepolia node rpc to connect.
+         */
+        RPC_URL_11155111: string
+        /**
+         * Ethereum mainnet node rpc to connect.
+         */
+        RPC_URL_1: string
+        /**
+         * alchemy Mainnet subgraph graphql endpoint.
+         */
+        ALCHEMY_MAINNET_URL: string
+        /**
+         *  chainstack Mainnet subgraph graphql endpoint.
+         */
+        CHAINSTACK_MAINNET_URL: string
+        /**
+         * chainstack sepolia subgraph graphql endpoint.
+         */
+        CHAINSTACK_SEPOLIA_URL: string
+    }
+}

--- a/package.json
+++ b/package.json
@@ -16,9 +16,18 @@
         ]
     },
     "scripts": {
-        "prettier": "prettier --check **/*.ts"
+        "prettier": "prettier --check **/*.ts",
+        "run:monitoring": "node --experimental-strip-types scripts/subgraph-monitoring.ts"
     },
     "devDependencies": {
-        "prettier": "2.7.1"
-    }
+        "@types/node": "22.18.10",
+        "graphql": "^16.11.0",
+        "graphql-request": "^7.2.0",
+        "prettier": "2.7.1",
+        "viem": "^2.38.2"
+    },
+    "engines": {
+        "node": "22.x"
+    },
+    "packageManager": "yarn@1.22.19"
 }

--- a/scripts/subgraph-monitoring.ts
+++ b/scripts/subgraph-monitoring.ts
@@ -103,11 +103,13 @@ async function main() {
         sepoliaChainstackDiff,
     ].some((diff) => absBigInt(diff) > blockDiffLimit)
 
-    if (isAboveThreshold) {
-        process.exit(1)
-    } else {
-        process.exit(0)
-    }
+    // if (isAboveThreshold) {
+    //     process.exit(1)
+    // } else {
+    //     process.exit(0)
+    // }
+
+    process.exit(1)
 }
 
 main()

--- a/scripts/subgraph-monitoring.ts
+++ b/scripts/subgraph-monitoring.ts
@@ -103,13 +103,11 @@ async function main() {
         sepoliaChainstackDiff,
     ].some((diff) => absBigInt(diff) > blockDiffLimit)
 
-    // if (isAboveThreshold) {
-    //     process.exit(1)
-    // } else {
-    //     process.exit(0)
-    // }
-
-    process.exit(1)
+    if (isAboveThreshold) {
+        process.exit(1)
+    } else {
+        process.exit(0)
+    }
 }
 
 main()

--- a/scripts/subgraph-monitoring.ts
+++ b/scripts/subgraph-monitoring.ts
@@ -1,0 +1,113 @@
+import { gql, request } from "graphql-request"
+import type { Hex } from "viem"
+import { createPublicClient, http } from "viem"
+import { mainnet, sepolia } from "viem/chains"
+
+const threshold = process.env.MONITOR_ALERT_THRESHOLD ?? "50"
+const sepoliaRpcUrl = process.env.RPC_URL_11155111
+const mainnetRpcUrl = process.env.RPC_URL_1
+const alchemyUrl = process.env.ALCHEMY_MAINNET_URL ?? ""
+const chainstackUrl = process.env.CHAINSTACK_MAINNET_URL ?? ""
+const sepoliaChainstackUrl = process.env.CHAINSTACK_SEPOLIA_URL ?? ""
+const blockDiffLimit = BigInt(threshold)
+
+const mainnetClient = createPublicClient({
+    chain: mainnet,
+    transport: http(mainnetRpcUrl),
+})
+const sepoliaClient = createPublicClient({
+    transport: http(sepoliaRpcUrl),
+    chain: sepolia,
+})
+
+interface Meta {
+    block: {
+        hash: Hex
+        number: number
+    }
+    deployment: string
+    hasIndexingErrors: boolean
+}
+
+interface MetaQuery {
+    _meta: Meta
+}
+
+const query = gql`
+    query _meta {
+        _meta {
+            block {
+                hash
+                number
+            }
+
+            deployment
+            hasIndexingErrors
+        }
+    }
+`
+
+const absBigInt = (n: bigint) => {
+    if (typeof n !== "bigint") {
+        throw new TypeError("Input must be a BigInt.")
+    }
+    return n < 0n ? -n : n
+}
+
+async function main() {
+    const mainnetPromises = Promise.all([
+        request<MetaQuery>(alchemyUrl, query),
+        request<MetaQuery>(chainstackUrl, query),
+        mainnetClient.getBlockNumber(),
+    ])
+
+    const sepoliaPromises = Promise.all([
+        request<MetaQuery>(sepoliaChainstackUrl, query),
+        sepoliaClient.getBlockNumber(),
+    ])
+
+    const [mainnetResults, sepoliaResults] = await Promise.all([
+        mainnetPromises,
+        sepoliaPromises,
+    ])
+
+    const [alchemyQuery, chainstackQuery, blockNumber] = mainnetResults
+    const [sepoliaChainstackQuery, sepoliaBlockNumber] = sepoliaResults
+
+    const alchemyBlockNumber = alchemyQuery?._meta?.block.number ?? 0
+    const chainstackBlockNumber = chainstackQuery?._meta?.block.number ?? 0
+    const sepoliaChainstackBlockNumber =
+        sepoliaChainstackQuery?._meta?.block.number ?? 0
+
+    const alchemyDiff = BigInt(alchemyBlockNumber) - blockNumber
+    const chainstackDiff = BigInt(chainstackBlockNumber) - blockNumber
+    const sepoliaChainstackDiff =
+        BigInt(sepoliaChainstackBlockNumber) - sepoliaBlockNumber
+
+    console.log(`MAINNET`)
+    console.log(`\tblockNumber: ${blockNumber}`)
+    console.log(`\talchemy: ${alchemyBlockNumber} diff: ${alchemyDiff}`)
+    console.log(
+        `\tchainstack: ${chainstackBlockNumber} diff: ${chainstackDiff}`
+    )
+
+    console.log(`SEPOLIA`)
+    console.log(`\tblockNumber: ${sepoliaBlockNumber}`)
+    console.log(
+        `\tchainstack: ${sepoliaChainstackBlockNumber} diff: ${sepoliaChainstackDiff}`
+    )
+
+    const isAboveThreshold = [
+        alchemyDiff,
+        chainstackDiff,
+        sepoliaChainstackDiff,
+    ].some((diff) => absBigInt(diff) > blockDiffLimit)
+
+    if (isAboveThreshold) {
+        process.exit(1)
+    } else {
+        process.exit(0)
+    }
+}
+
+main()

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,5 +11,6 @@
         "paths": {
             "~/*": ["packages/*"]
         }
-    }
+    },
+    "include": ["additional.d.ts"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,11 @@
 # yarn lockfile v1
 
 
+"@adraffy/ens-normalize@^1.11.0":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@adraffy/ens-normalize/-/ens-normalize-1.11.1.tgz#6c2d657d4b2dfb37f8ea811dcb3e60843d4ac24a"
+  integrity sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==
+
 "@babel/code-frame@^7.0.0":
   version "7.22.13"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.22.13.tgz#e3c1c099402598483b7a8c46a721d1038803755e"
@@ -751,6 +756,11 @@
   dependencies:
     assemblyscript "0.19.10"
 
+"@graphql-typed-document-node/core@^3.2.0":
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/@graphql-typed-document-node/core/-/core-3.2.0.tgz#5f3d96ec6b2354ad6d8a28bf216a1d97b5426861"
+  integrity sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==
+
 "@ipld/dag-cbor@^7.0.0":
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/@ipld/dag-cbor/-/dag-cbor-7.0.3.tgz#aa31b28afb11a807c3d627828a344e5521ac4a1e"
@@ -808,12 +818,31 @@
     tweetnacl "^1.0.3"
     tweetnacl-util "^0.15.1"
 
+"@noble/ciphers@^1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@noble/ciphers/-/ciphers-1.3.0.tgz#f64b8ff886c240e644e5573c097f86e5b43676dc"
+  integrity sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==
+
 "@noble/curves@1.1.0", "@noble/curves@~1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@noble/curves/-/curves-1.1.0.tgz#f13fc667c89184bc04cccb9b11e8e7bae27d8c3d"
   integrity sha512-091oBExgENk/kGj3AZmtBDMpxQPDtxQABR2B9lb1JbVTs6ytdzZNwvhxQ4MWasRNEzlbEH8jCWFCwhF/Obj5AA==
   dependencies:
     "@noble/hashes" "1.3.1"
+
+"@noble/curves@1.9.1":
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/@noble/curves/-/curves-1.9.1.tgz#9654a0bc6c13420ae252ddcf975eaf0f58f0a35c"
+  integrity sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==
+  dependencies:
+    "@noble/hashes" "1.8.0"
+
+"@noble/curves@~1.9.0":
+  version "1.9.7"
+  resolved "https://registry.yarnpkg.com/@noble/curves/-/curves-1.9.7.tgz#79d04b4758a43e4bca2cbdc62e7771352fa6b951"
+  integrity sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==
+  dependencies:
+    "@noble/hashes" "1.8.0"
 
 "@noble/hashes@1.2.0", "@noble/hashes@~1.2.0":
   version "1.2.0"
@@ -824,6 +853,11 @@
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.3.1.tgz#8831ef002114670c603c458ab8b11328406953a9"
   integrity sha512-EbqwksQwz9xDRGfDST86whPBgM65E0OH/pCgqW0GBVzO22bNE+NuIbeTb714+IfSjU3aRk47EUvXIb5bTsenKA==
+
+"@noble/hashes@1.8.0", "@noble/hashes@^1.8.0", "@noble/hashes@~1.8.0":
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.8.0.tgz#cee43d801fcef9644b11b8194857695acd5f815a"
+  integrity sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==
 
 "@noble/hashes@~1.3.0", "@noble/hashes@~1.3.1":
   version "1.3.2"
@@ -1285,6 +1319,11 @@
   resolved "https://registry.yarnpkg.com/@scure/base/-/base-1.1.2.tgz#ff0cf51874aaf176490c9cb46e4df807a2e581d2"
   integrity sha512-sSCrnIdaUZQHhBxZThMuk7Wm1TWzMD3uJNdGgx3JS23xSqevu0tAOsg8k66nL3R2NwQe65AI9GgqpPOgZys/eA==
 
+"@scure/base@~1.2.5":
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/@scure/base/-/base-1.2.6.tgz#ca917184b8231394dd8847509c67a0be522e59f6"
+  integrity sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==
+
 "@scure/bip32@1.1.5":
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/@scure/bip32/-/bip32-1.1.5.tgz#d2ccae16dcc2e75bc1d75f5ef3c66a338d1ba300"
@@ -1303,6 +1342,15 @@
     "@noble/hashes" "~1.3.1"
     "@scure/base" "~1.1.0"
 
+"@scure/bip32@1.7.0", "@scure/bip32@^1.7.0":
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/@scure/bip32/-/bip32-1.7.0.tgz#b8683bab172369f988f1589640e53c4606984219"
+  integrity sha512-E4FFX/N3f4B80AKWp5dP6ow+flD1LQZo/w8UnLGYZO674jS6YnYeepycOOksv+vLPSpgN35wgKgy+ybfTb2SMw==
+  dependencies:
+    "@noble/curves" "~1.9.0"
+    "@noble/hashes" "~1.8.0"
+    "@scure/base" "~1.2.5"
+
 "@scure/bip39@1.1.1":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@scure/bip39/-/bip39-1.1.1.tgz#b54557b2e86214319405db819c4b6a370cf340c5"
@@ -1318,6 +1366,14 @@
   dependencies:
     "@noble/hashes" "~1.3.0"
     "@scure/base" "~1.1.0"
+
+"@scure/bip39@1.6.0", "@scure/bip39@^1.6.0":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@scure/bip39/-/bip39-1.6.0.tgz#475970ace440d7be87a6086cbee77cb8f1a684f9"
+  integrity sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A==
+  dependencies:
+    "@noble/hashes" "~1.8.0"
+    "@scure/base" "~1.2.5"
 
 "@sentry/core@5.30.0":
   version "5.30.0"
@@ -1645,6 +1701,13 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-20.5.7.tgz#4b8ecac87fbefbc92f431d09c30e176fc0a7c377"
   integrity sha512-dP7f3LdZIysZnmvP3ANJYTSwg+wLLl8p7RqniVlV7j+oXSXAbt9h0WIBFmJy5inWZoX9wZN6eXx+YXd9Rh3RBA==
 
+"@types/node@22.18.10":
+  version "22.18.10"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-22.18.10.tgz#37f0ac8d2ec41af7bba06f162c85ff409e4e3420"
+  integrity sha512-anNG/V/Efn/YZY4pRzbACnKxNKoBng2VTFydVu8RRs5hQjikP8CQfaeAV59VFSCzKNp90mXiVXW2QzV56rwMrg==
+  dependencies:
+    undici-types "~6.21.0"
+
 "@types/node@^10.0.3":
   version "10.17.60"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.17.60.tgz#35f3d6213daed95da7f0f73e75bcc6980e90597b"
@@ -1770,6 +1833,16 @@ JSONStream@^1.3.5:
   dependencies:
     jsonparse "^1.2.0"
     through ">=2.2.7 <3"
+
+abitype@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/abitype/-/abitype-1.1.0.tgz#510c5b3f92901877977af5e864841f443bf55406"
+  integrity sha512-6Vh4HcRxNMLA0puzPjM5GBgT4aAcFGKZzSgAXvuZ27shJP6NEpielTuqbBmZILR5/xd0PizkBGy5hReKz9jl5A==
+
+abitype@^1.0.9:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/abitype/-/abitype-1.1.1.tgz#b50ed400f8bfca5452eb4033445c309d3e1117c8"
+  integrity sha512-Loe5/6tAgsBukY95eGaPSDmQHIjRZYQq8PB1MpsNccDIK8WiV+Uw6WzaIXipvaxTEL2yEB0OpEaQv3gs8pkS9Q==
 
 abort-controller@^3.0.0:
   version "3.0.0"
@@ -5084,6 +5157,11 @@ eventemitter3@4.0.4:
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-4.0.4.tgz#b5463ace635a083d018bdc7c917b4c5f10a85384"
   integrity sha512-rlaVLnVxtxvoyLsQQFBx53YmXHDxRIzzTLbdfxqi4yocpSjAxXwkU0cScM5JgSKMqEhrZpnvQ2D9gjylR0AimQ==
 
+eventemitter3@5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-5.0.1.tgz#53f5ffd0a492ac800721bb42c66b841de96423c4"
+  integrity sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==
+
 events@^3.0.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/events/-/events-3.3.0.tgz#31a95ad0a924e2d2c419a813aeb2c4e878ea7400"
@@ -5993,10 +6071,22 @@ graphql-import-node@^0.0.5:
   resolved "https://registry.yarnpkg.com/graphql-import-node/-/graphql-import-node-0.0.5.tgz#caf76a6cece10858b14f27cce935655398fc1bf0"
   integrity sha512-OXbou9fqh9/Lm7vwXT0XoRN9J5+WCYKnbiTalgFDvkQERITRmcfncZs6aVABedd5B85yQU5EULS4a5pnbpuI0Q==
 
+graphql-request@^7.2.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/graphql-request/-/graphql-request-7.2.0.tgz#af4aa25f27a087dd4fc93a4ff54a0f59c4487269"
+  integrity sha512-0GR7eQHBFYz372u9lxS16cOtEekFlZYB2qOyq8wDvzRmdRSJ0mgUVX1tzNcIzk3G+4NY+mGtSz411wZdeDF/+A==
+  dependencies:
+    "@graphql-typed-document-node/core" "^3.2.0"
+
 graphql@15.5.0:
   version "15.5.0"
   resolved "https://registry.yarnpkg.com/graphql/-/graphql-15.5.0.tgz#39d19494dbe69d1ea719915b578bf920344a69d5"
   integrity sha512-OmaM7y0kaK31NKG31q4YbD2beNYa6jBBKtMFT6gLYJljHLJr42IqJ8KX08u3Li/0ifzTU5HjmoOOrwa5BRLeDA==
+
+graphql@^16.11.0:
+  version "16.11.0"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-16.11.0.tgz#96d17f66370678027fdf59b2d4c20b4efaa8a633"
+  integrity sha512-mS1lbMsxgQj6hge1XZ6p7GPhbrtFwUFYi3wRzXAC/FmYnyXMTvvI3td3rjmQ2u8ewXueaSvRPWaEcgVVOT9Jnw==
 
 graphql@^16.6.0:
   version "16.8.0"
@@ -7039,6 +7129,11 @@ isomorphic-ws@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/isomorphic-ws/-/isomorphic-ws-4.0.1.tgz#55fd4cd6c5e6491e76dc125938dd863f5cd4f2dc"
   integrity sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==
+
+isows@1.0.7:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/isows/-/isows-1.0.7.tgz#1c06400b7eed216fbba3bcbd68f12490fc342915"
+  integrity sha512-I1fSfDCZL5P0v33sVqeTDSpcstAg/N+wF5HS033mogOVIp4B+oHC7oOCsA3axAbBSGTJ8QubbNmnIRN/h8U7hg==
 
 isstream@~0.1.2:
   version "0.1.2"
@@ -8703,6 +8798,20 @@ os-tmpdir@^1.0.1, os-tmpdir@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
   integrity sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==
+
+ox@0.9.6:
+  version "0.9.6"
+  resolved "https://registry.yarnpkg.com/ox/-/ox-0.9.6.tgz#5cf02523b6db364c10ee7f293ff1e664e0e1eab7"
+  integrity sha512-8SuCbHPvv2eZLYXrNmC0EC12rdzXQLdhnOMlHDW2wiCPLxBrOOJwX5L5E61by+UjTPOryqQiRSnjIKCI+GykKg==
+  dependencies:
+    "@adraffy/ens-normalize" "^1.11.0"
+    "@noble/ciphers" "^1.3.0"
+    "@noble/curves" "1.9.1"
+    "@noble/hashes" "^1.8.0"
+    "@scure/bip32" "^1.7.0"
+    "@scure/bip39" "^1.6.0"
+    abitype "^1.0.9"
+    eventemitter3 "5.0.1"
 
 p-cancelable@^1.0.0:
   version "1.1.0"
@@ -11001,6 +11110,11 @@ underscore@^1.8.3:
   resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.13.6.tgz#04786a1f589dc6c09f761fc5f45b89e935136441"
   integrity sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A==
 
+undici-types@~6.21.0:
+  version "6.21.0"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-6.21.0.tgz#691d00af3909be93a7faa13be61b3a5b50ef12cb"
+  integrity sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==
+
 undici@^5.14.0:
   version "5.23.0"
   resolved "https://registry.yarnpkg.com/undici/-/undici-5.23.0.tgz#e7bdb0ed42cebe7b7aca87ced53e6eaafb8f8ca0"
@@ -11207,6 +11321,20 @@ verror@1.10.0:
     assert-plus "^1.0.0"
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
+
+viem@^2.38.2:
+  version "2.38.2"
+  resolved "https://registry.yarnpkg.com/viem/-/viem-2.38.2.tgz#55d7c2f44b52cfbafa822f24aa796cc2ac5afd78"
+  integrity sha512-MJDiTDD9gfOT7lPQRimdmw+g46hU/aWJ3loqb+tN6UBOO00XEd0O4LJx+Kp5/uCRnMlJr8zJ1bNzCK7eG6gMjg==
+  dependencies:
+    "@noble/curves" "1.9.1"
+    "@noble/hashes" "1.8.0"
+    "@scure/bip32" "1.7.0"
+    "@scure/bip39" "1.6.0"
+    abitype "1.1.0"
+    isows "1.0.7"
+    ox "0.9.6"
+    ws "8.18.3"
 
 wabt@1.0.24:
   version "1.0.24"
@@ -12117,6 +12245,11 @@ ws@7.4.6:
   version "7.4.6"
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.4.6.tgz#5654ca8ecdeee47c33a9a4bf6d28e2be2980377c"
   integrity sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==
+
+ws@8.18.3:
+  version "8.18.3"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.18.3.tgz#b56b88abffde62791c639170400c93dcb0c95472"
+  integrity sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==
 
 ws@^3.0.0:
   version "3.3.3"


### PR DESCRIPTION
### Summary
The addition of a new schedule action to keep monitoring delays in the indexed blocks in all hosted subgraphs we have. It has a threshold configured (currently 50 blocks). If any of the checked deployed subgraphs exceed that limit in terms of difference, the action will create an issue and mention the team `cartesi/explorer` so the people in that team will be notified. 

Requirements: 
- A registered GitHub App with required permissions, followed by installing it in the Org and mapping the repository.

Reference: https://github.com/orgs/community/discussions/43415#discussioncomment-9941115

ps: _without the permissions, the bot will mention the team, but GitHub will not schedule an email_